### PR TITLE
Change user registration flow

### DIFF
--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -5,8 +5,9 @@ module Users
       if @user.persisted?
         sign_in_and_redirect @user
       else
-        flash[:warning] = t('need_sign_up')
-        redirect_to new_user_registration_path
+        @user.save(validate: false)
+        sign_in @user
+        redirect_to edit_profile_users_path
       end
     end
   end

--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -1,0 +1,11 @@
+module Users
+  class PasswordsController < Devise::PasswordsController
+    def create
+      if User.find_by(email: resource_params['email'], provider: 'oktaoauth')
+        redirect_to "#{ENV['OKTA_URL']}/enduser/settings"
+      else
+        super
+      end
+    end
+  end
+end

--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -2,7 +2,7 @@ module Users
   class PasswordsController < Devise::PasswordsController
     def create
       if User.find_by(email: resource_params['email'], provider: 'oktaoauth')
-        redirect_to "#{ENV['OKTA_URL']}/enduser/settings"
+        redirect_to URI.join(Rails.configuration.okta_url, '/enduser/settings').to_s
       else
         super
       end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -27,7 +27,7 @@ class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :validatable,
+         :recoverable, :rememberable, :validatable, :timeoutable,
          :omniauthable, omniauth_providers: [:oktaoauth]
 
   acts_as_paranoid

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -51,7 +51,12 @@
             </a>
             <ul class="dropdown-menu">
               <li><%= link_to t('.profile'), current_users_path %></li>
-              <li><%= link_to t('.settings'), edit_user_registration_path %></li>
+              <li><%= link_to t('.edit_profile'), edit_profile_users_path %></li>
+              <% if current_user.uid.nil? %>
+                <li><%= link_to t('.change_pass'), edit_user_registration_path %></li>
+              <% else %>
+                <li><%= link_to t('.change_pass'), "#{ENV['OKTA_URL']}/enduser/settings" %></li>
+              <% end %>
               <li><%= link_to t('.block_list'), declined_users_path %></li>
               <li class="divider"></li>
               <li>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -55,7 +55,7 @@
               <% if current_user.uid.nil? %>
                 <li><%= link_to t('.change_pass'), edit_user_registration_path %></li>
               <% else %>
-                <li><%= link_to t('.change_pass'), "#{ENV['OKTA_URL']}/enduser/settings" %></li>
+                <li><%= link_to t('.change_pass'), URI.join(Rails.configuration.okta_url, '/enduser/settings').to_s %></li>
               <% end %>
               <li><%= link_to t('.block_list'), declined_users_path %></li>
               <li class="divider"></li>

--- a/config/initializers/configuration.rb
+++ b/config/initializers/configuration.rb
@@ -1,0 +1,1 @@
+Rails.configuration.okta_url = ENV.fetch('OKTA_URL', '')

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -73,8 +73,8 @@ en:
     index:
       title: "Search results for \"%{search}\""
     edit:
-      title: "Edit user"
-      submit: "Update"
+      title: "User profile"
+      submit: "Save"
       cancel: "Cancel"
       remove: "Remove my account"
       sure: "Are you sure?"
@@ -170,7 +170,8 @@ en:
   layouts:
     header:
       profile: "Profile"
-      settings: "Settings"
+      edit_profile: "Edit profile"
+      change_pass: "Change password"
       block_list: "Block list"
       log_in: "Log in"
       log_out: "Log out"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -60,7 +60,7 @@ en:
     passwords:
       new:
         title: "Forgot your password?"
-        submit: "Send me reset password instructions"
+        submit: "Reset password"
       edit:
         title: "Change your password"
         submit: "Change my password"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,7 @@
 Rails.application.routes.draw do
   root 'posts#index'
-  devise_for :users, controllers: { omniauth_callbacks: 'users/omniauth_callbacks' }
+  devise_for :users, controllers: { omniauth_callbacks: 'users/omniauth_callbacks',
+                                    passwords: 'users/passwords' }
 
   resources :users, only: %i[index show] do
     collection do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -84,4 +84,40 @@ RSpec.describe User, type: :model do
       expect(user.show_post_for?(user)).to be true
     end
   end
+
+  describe 'from_omniath' do
+    let!(:user) { create(:user) }
+    let!(:existing_user_okta_hash) do
+      OmniAuth::AuthHash.new({
+                               'provider' => 'oktaoauth',
+                               'uid' => '12345',
+                               'info' => {
+                                 'email' => user.email
+                               }
+                             })
+    end
+    let!(:new_user_okta_hash) do
+      OmniAuth::AuthHash.new({
+                               'provider' => 'oktaoauth',
+                               'uid' => '67890',
+                               'info' => {
+                                 'email' => 'okta_email@test.net'
+                               }
+                             })
+    end
+
+    it 'should update uid and provider of existing user' do
+      User.from_omniauth(existing_user_okta_hash)
+      user.reload
+      expect(user.uid).to eq(existing_user_okta_hash['uid'])
+      expect(user.provider).to eq(existing_user_okta_hash['provider'])
+    end
+
+    it 'should return new user' do
+      new_user = User.from_omniauth(new_user_okta_hash)
+      expect(new_user.uid).to eq(new_user_okta_hash['uid'])
+      expect(new_user.provider).to eq(new_user_okta_hash['provider'])
+      expect(new_user.email).to eq(new_user_okta_hash['info']['email'])
+    end
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -89,20 +89,16 @@ RSpec.describe User, type: :model do
     let!(:user) { create(:user) }
     let!(:existing_user_okta_hash) do
       OmniAuth::AuthHash.new({
-                               'provider' => 'oktaoauth',
-                               'uid' => '12345',
-                               'info' => {
-                                 'email' => user.email
-                               }
+                               provider: 'oktaoauth',
+                               uid: '12345',
+                               info: { email: user.email }
                              })
     end
     let!(:new_user_okta_hash) do
       OmniAuth::AuthHash.new({
-                               'provider' => 'oktaoauth',
-                               'uid' => '67890',
-                               'info' => {
-                                 'email' => 'okta_email@test.net'
-                               }
+                               provider: 'oktaoauth',
+                               ui: '67890',
+                               info: { email: 'okta_email@test.net' }
                              })
     end
 


### PR DESCRIPTION
1. New User record will be created if new user signs in with okta.
2. User can not use email/password for signing in if he uses okta.
3. User will be redirected to okta profile page for changing password if he use okta for singing in.
4. Session expires in 30 minutes