### PR TITLE
Change flow for new okta users

### DIFF
--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -5,9 +5,8 @@ module Users
       if @user.persisted?
         sign_in_and_redirect @user
       else
-        @user.save(validate: false)
-        sign_in @user
-        redirect_to edit_profile_users_path
+        @user.errors.clear
+        render 'users/new'
       end
     end
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,5 @@
 class UsersController < ApplicationController
-  before_action :authenticate_user!
+  before_action :authenticate_user!, except: :create
   before_action :obtain_user, only: %i[show following followers]
   before_action :obtain_current_user, only: %i[edit update]
   before_action :obtain_active_relationships, only: %i[index show]
@@ -11,6 +11,15 @@ class UsersController < ApplicationController
   def show
     redirect_to current_users_path if @user == current_user
     @posts = @user.posts.order(created_at: :desc)
+  end
+
+  def create
+    @user = User.new(user_params)
+    if @user.save
+      sign_in_and_redirect @user
+    else
+      render 'new'
+    end
   end
 
   def edit; end
@@ -45,8 +54,8 @@ class UsersController < ApplicationController
   private
 
   def user_params
-    params.require(:user).permit(:name, :nickname, :email, :private, :avatar,
-                                 :avatar_cache, :remove_avatar)
+    params.require(:user).permit(:name, :nickname, :email, :password, :provider, :uid,
+                                 :private, :avatar, :avatar_cache, :remove_avatar)
   end
 
   def obtain_user

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -39,19 +39,29 @@ class User < ApplicationRecord
 
   def self.from_omniauth(auth)
     if (user = find_by(email: auth['info']['email']))
-      user.update(okta_params(auth))
+      user.update(edit_okta_params(auth))
     else
-      user = create(okta_params(auth))
+      user = create(new_okta_params(auth))
     end
 
     user
   end
 
-  def self.okta_params(auth)
+  def self.new_okta_params(auth)
+    {
+      name: auth['info']['name'],
+      nickname: auth['extra']['raw_info']['nickname'],
+      email: auth['info']['email'],
+      provider: auth['provider'],
+      uid: auth['uid'],
+      password: Devise.friendly_token[0, 20]
+    }
+  end
+
+  def self.edit_okta_params(auth)
     {
       provider: auth['provider'],
       uid: auth['uid'],
-      email: auth['info']['email'],
       password: Devise.friendly_token[0, 20]
     }
   end

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,0 +1,22 @@
+<h2><%= t('.title') %></h2>
+
+<div class="row">
+  <div class="col-md-6 col-md-offset-3">
+    <div class="edit-form">
+      <%= simple_form_for @user, url: create_profile_users_path, method: :post do |f| %>
+        <div class="form-inputs">
+          <%= f.input :name %>
+          <%= f.input :nickname %>
+          <%= f.input :email, required: true %>
+          <%= f.hidden_field :password %>
+          <%= f.hidden_field :provider %>
+          <%= f.hidden_field :uid %>
+        </div>
+        <div class="form-actions">
+          <%= f.button :submit, t('.submit'), class: "btn btn-primary" %>
+        </div>
+      <% end %>
+      <%= link_to t('.cancel'), root_path, class: "btn btn-default wide-button" %>
+    </div>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -79,8 +79,12 @@ en:
   users:
     index:
       title: "Search results for \"%{search}\""
+    new:
+      title: "Create profile"
+      submit: "Save"
+      cancel: "Cancel"
     edit:
-      title: "User profile"
+      title: "Edit profile"
       submit: "Save"
       cancel: "Cancel"
       remove: "Remove my account"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,7 @@ Rails.application.routes.draw do
       get :current, :declined
       get :edit_profile, to: 'users#edit'
       patch :update_profile, to: 'users#update'
+      post :create_profile, to: 'users#create'
     end
 
     member do

--- a/spec/controllers/users/omniauth_callbacks_controller_spec.rb
+++ b/spec/controllers/users/omniauth_callbacks_controller_spec.rb
@@ -2,21 +2,51 @@ require 'rails_helper'
 
 RSpec.describe Users::OmniauthCallbacksController, type: :controller do
   let!(:existing_user) { create(:user, provider: 'oktaoauth', uid: '12345') }
+
   let!(:existing_user_okta_hash) do
     OmniAuth::AuthHash.new({
                              provider: existing_user.provider,
                              uid: existing_user.uid,
                              info: {
-                               email: existing_user.email
+                               email: existing_user.email,
+                               name: 'Existing User'
+                             },
+                             extra: {
+                               raw_info: {
+                                 nickname: 'existing_user'
+                               }
                              }
                            })
   end
-  let!(:new_user_okta_hash) do
+
+  let!(:new_valid_user_okta_hash) do
     OmniAuth::AuthHash.new({
                              provider: 'oktaoauth',
-                             uid: '67890',
+                             uid: '12346',
                              info: {
-                               email: 'new_user@test.net'
+                               email: 'new_user@test.net',
+                               name: 'New User'
+                             },
+                             extra: {
+                               raw_info: {
+                                 nickname: 'new_user'
+                               }
+                             }
+                           })
+  end
+
+  let!(:new_invalid_user_okta_hash) do
+    OmniAuth::AuthHash.new({
+                             provider: 'oktaoauth',
+                             uid: '12347',
+                             info: {
+                               email: 'new_user@test.net',
+                               name: ''
+                             },
+                             extra: {
+                               raw_info: {
+                                 nickname: ''
+                               }
                              }
                            })
   end
@@ -29,7 +59,6 @@ RSpec.describe Users::OmniauthCallbacksController, type: :controller do
     context 'existing user' do
       before do
         request.env['omniauth.auth'] = existing_user_okta_hash
-
         get :oktaoauth
       end
 
@@ -42,19 +71,35 @@ RSpec.describe Users::OmniauthCallbacksController, type: :controller do
       end
     end
 
-    context 'new user' do
+    context 'new valid user' do
       before do
-        request.env['omniauth.auth'] = new_user_okta_hash
+        request.env['omniauth.auth'] = new_valid_user_okta_hash
 
         get :oktaoauth
       end
 
       it 'redirect to root_path' do
-        expect(response).to redirect_to(edit_profile_users_path)
+        expect(response).to redirect_to(root_path)
       end
 
       it 'should have a current_user' do
         expect(subject.current_user).to_not eq(nil)
+      end
+    end
+
+    context 'new invalid user' do
+      before do
+        request.env['omniauth.auth'] = new_invalid_user_okta_hash
+
+        get :oktaoauth
+      end
+
+      it 'redirect to root_path' do
+        expect(response).to render_template('new')
+      end
+
+      it 'should have a current_user' do
+        expect(subject.current_user).to eq(nil)
       end
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -113,7 +113,15 @@ RSpec.describe User, type: :model do
       OmniAuth::AuthHash.new({
                                provider: 'oktaoauth',
                                ui: '67890',
-                               info: { email: 'okta_email@test.net' }
+                               info: {
+                                 email: 'okta_email@test.net',
+                                 name: 'New User'
+                               },
+                               extra: {
+                                 raw_info: {
+                                   nickname: 'new_user'
+                                 }
+                               }
                              })
     end
 
@@ -129,6 +137,8 @@ RSpec.describe User, type: :model do
       expect(new_user.uid).to eq(new_user_okta_hash['uid'])
       expect(new_user.provider).to eq(new_user_okta_hash['provider'])
       expect(new_user.email).to eq(new_user_okta_hash['info']['email'])
+      expect(new_user.name).to eq(new_user_okta_hash['info']['name'])
+      expect(new_user.nickname).to eq(new_user_okta_hash['extra']['raw_info']['nickname'])
     end
   end
 end


### PR DESCRIPTION
Email, name and nickname for new users are taken from okta account.
If @user is valid, he will be redirected to home page.
If @user is invalid (e.g., name or nickname are empty in okta account, nickname is not unique), it will be rendered 'users/new' template.
Invalid users are not saved in db anymore
![Screenshot 2021-06-01 at 10 47 49](https://user-images.githubusercontent.com/10636041/120286624-23cf4a00-c2c7-11eb-9fd0-00c9c6a7a737.png)
.
